### PR TITLE
Limit the size of regex cache

### DIFF
--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -398,7 +398,7 @@ var (
 
 	// MAX_REGEX_CACHE_CAPACITY limits the number of cached regular expressions,
 	// to prevent it from growing indefinitely
-	MAX_REGEX_CACHE_CAPACITY = 100
+	MAX_REGEX_CACHE_CAPACITY = 500
 )
 
 // INTERNATIONAL and NATIONAL formats are consistent with the definition

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -601,7 +601,7 @@ var ErrEmptyMetadata = errors.New("empty metadata")
 
 // SetRegexCacheCapacity sets the regex cache capacity
 // to the given positive number
-func SetRegexCacheCapacity(cap int) err {
+func SetRegexCacheCapacity(cap int) error {
 	if cap <= 0 {
 		return ErrInvalidCapacity
 	}
@@ -610,6 +610,13 @@ func SetRegexCacheCapacity(cap int) err {
 	MAX_REGEX_CACHE_CAPACITY = cap
 	regCacheMutex.Unlock()
 	return nil
+}
+
+// ClearRegexCache Clears the regex cache
+func ClearRegexCache() {
+	regCacheMutex.Lock()
+	regexCache = make(map[string]*regexp.Regexp)
+	regCacheMutex.Unlock()
 }
 
 func readFromRegexCache(key string) (*regexp.Regexp, bool) {

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -25,6 +25,9 @@ const (
 	// This prevents malicious input from overflowing the regular-expression
 	// engine.
 	MAX_INPUT_STRING_LENGTH = 250
+	// MAX_REGEX_CACHE_CAPACITY limits the number of cached regular expressions,
+	// to prevent it from growing indefinitely
+	MAX_REGEX_CACHE_CAPACITY = 50
 
 	// UNKNOWN_REGION is the region-code for the unknown region.
 	UNKNOWN_REGION = "ZZ"
@@ -604,8 +607,11 @@ func readFromRegexCache(key string) (*regexp.Regexp, bool) {
 
 func writeToRegexCache(key string, value *regexp.Regexp) {
 	regCacheMutex.Lock()
+	defer regCacheMutex.Unlock()
+	if len(regexCache) == MAX_REGEX_CACHE_CAPACITY {
+		return
+	}
 	regexCache[key] = value
-	regCacheMutex.Unlock()
 }
 
 func regexFor(pattern string) *regexp.Regexp {

--- a/phonenumbers.go
+++ b/phonenumbers.go
@@ -609,6 +609,7 @@ func SetRegexCacheCapacity(cap int) err {
 	regCacheMutex.Lock()
 	MAX_REGEX_CACHE_CAPACITY = cap
 	regCacheMutex.Unlock()
+	return nil
 }
 
 func readFromRegexCache(key string) (*regexp.Regexp, bool) {


### PR DESCRIPTION
Due to investigations on memory usage in our app, we have identified that the map structure for caching region-specific regular expressions grows indefinitely.

In this PR, we try to limit the capacity of the map so the size of it stays even. The capacity can be set dynamically by `SetRegexCacheCapacity` function.